### PR TITLE
implement SafeArea to drawer icon

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -19,10 +19,7 @@ class HomePage extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Padding(
-                  padding: EdgeInsets.only(
-                    top: SizeConfig.safeBlockVertical * 3,
-                  ),
+                SafeArea(
                   child: IconButton(
                     onPressed: () {
                       globalKey.currentState!.openDrawer();


### PR DESCRIPTION
I've removed padding from the icon button of the drawer screen and replaced it with safe area. On some devices, drawer icon cannot be accessed because the notification bar is above it and it absorbs the pointer event making it difficult to open the drawer. 
